### PR TITLE
fix: 修复指令前缀失效导致的指令头误判问题

### DIFF
--- a/plugins/alicebot_plugin_base/__init__.py
+++ b/plugins/alicebot_plugin_base/__init__.py
@@ -70,7 +70,7 @@ class CommandPluginBase(RegexPluginBase[T_State, T_CommandPluginConfig], ABC):
     def str_match(self, msg_str: str) -> bool:
         if not hasattr(self, "command_re_pattern"):
             self.command_re_pattern = re.compile(
-                f'({"|".join(self.config.command_prefix)})'
+                f'[{"".join(self.config.command_prefix)}]'
                 f'({"|".join(self.config.command)})'
                 r"\s*(?P<command_args>.*)",
                 flags=re.I if self.config.ignore_case else 0,


### PR DESCRIPTION
原因
-----

原 `command_prefix` 内有 ` .`, 加上原先的 `"|".join()` 写法会导致匹配任意一个字符与指令名后皆可触发指令